### PR TITLE
HW 11

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,6 +18,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: ANTLR grammar generation
+        run : |
+          antlr4 -Dlanguage=Python3 -Xexact-output-dir project/graphminusminus.g4 -o project/graphminusminus
 
       - name: Run tests
         run: |

--- a/project/gll_reachability_task09.py
+++ b/project/gll_reachability_task09.py
@@ -22,10 +22,12 @@ def cfpq_with_gll(
         else cfg_to_rsm(cfg_or_rsm)
     )
 
-    start_nodes = graph.nodes if start_nodes is None else start_nodes
-    final_nodes = graph.nodes if final_nodes is None else final_nodes
+    start_nodes = set(graph.nodes) if start_nodes is None else start_nodes
+    final_nodes = set(graph.nodes) if final_nodes is None else final_nodes
 
-    rsm_start_nonterminal = rsm.initial_label.value
+    rsm_start_nonterminal = (
+        rsm.initial_label.value if rsm.initial_label.value is not None else "S"
+    )
 
     stack_start_states = {
         (rsm_start_nonterminal, start_node) for start_node in start_nodes

--- a/project/graphminusminus.g4
+++ b/project/graphminusminus.g4
@@ -1,0 +1,43 @@
+grammar graphminusminus;
+
+prog: stmt* EOF;
+
+stmt: bind | add | remove | declare;
+
+declare: 'let' VAR 'is' 'graph';
+
+bind: 'let' VAR '=' expr;
+
+remove
+    : 'remove' ('vertex' | 'edge' | 'vertices') expr 'from' VAR;
+
+add: 'add' ('vertex' | 'edge') expr 'to' VAR;
+
+expr: NUM | CHAR | VAR | edgeExpr | setExpr | regexp | select;
+
+setExpr: '[' expr (',' expr)* ']';
+
+edgeExpr: '(' expr ',' expr ',' expr ')';
+
+regexp
+    : CHAR
+    | VAR
+    | '(' regexp ')'
+    | regexp '|' regexp
+    | regexp '^' range
+    | regexp '.' regexp
+    | regexp '&' regexp;
+
+range: '[' NUM '..' NUM? ']';
+
+select
+    : vFilter? vFilter? 'return' VAR (',' VAR)? 'where' VAR 'reachable' 'from' VAR 'in' VAR 'by'
+        expr;
+
+vFilter: 'for' VAR 'in' expr;
+
+VAR: [a-z][a-z0-9]*;
+NUM: '0' | ([1-9][0-9]*);
+CHAR: '"' [a-z] '"';
+
+WS: [ \r\n\t]+ -> skip;

--- a/project/parser_task11.py
+++ b/project/parser_task11.py
@@ -1,0 +1,47 @@
+from project.graphminusminus.graphminusminusLexer import graphminusminusLexer
+from project.graphminusminus.graphminusminusListener import graphminusminusListener
+from project.graphminusminus.graphminusminusParser import graphminusminusParser
+
+from antlr4 import Parser, ParserRuleContext, CommonTokenStream
+from antlr4.InputStream import InputStream
+
+
+class NodeCounter(graphminusminusListener):
+    counter: int = 0
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def enterEveryRule(self, ctx: ParserRuleContext) -> None:
+        self.counter += 1
+
+
+class NodeStringify(graphminusminusListener):
+    resString: str = ""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def enterEveryRule(self, ctx: ParserRuleContext) -> None:
+        self.resString += ctx.getText()
+
+
+# Второе поле показывает корректна ли строка (True, если корректна)
+def prog_to_tree(prog: str) -> tuple[ParserRuleContext, bool]:
+    parser = graphminusminusParser(
+        CommonTokenStream(graphminusminusLexer(InputStream(prog)))
+    )
+    prog: ParserRuleContext = parser.prog()
+    return prog, parser.getNumberOfSyntaxErrors() == 0
+
+
+def nodes_count(tree: ParserRuleContext) -> int:
+    listener = NodeCounter()
+    tree.enterRule(listener)
+    return listener.counter
+
+
+def tree_to_prog(tree: ParserRuleContext) -> str:
+    listener = NodeStringify()
+    tree.enterRule(listener)
+    return listener.resString

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 antlr4-python3-runtime
+antlr4-tools
 black
 cfpq_data
 grammarinator @ git+https://github.com/renatahodovan/grammarinator.git@f3ffa71

--- a/tests/autotests/test_task11.py
+++ b/tests/autotests/test_task11.py
@@ -1,88 +1,88 @@
-# # This file contains test cases that you need to pass to get a grade
-# # You MUST NOT touch anything here except ONE block below
-# # You CAN modify this file IF AND ONLY IF you have found a bug and are willing to fix it
-# # Otherwise, please report it
-# import inspect
-# import io
-# from contextlib import redirect_stdout
-#
-# import pytest
-# import re
-# from grammarinator.runtime import RuleSize, simple_space_serializer
-# from grammarinator.tool import (
-#     PickleTreeCodec,
-#     GeneratorTool,
-#     DefaultGeneratorFactory,
-#     DefaultPopulation,
-# )
-#
-# import ProgramGenerator
-#
-# # Fix import statements in try block to run tests
-# try:
-#     from project.task11 import prog_to_tree, nodes_count, tree_to_prog
-# except ImportError:
-#     pytestmark = pytest.mark.skip("Task 11 is not ready to test!")
-#
-#
-# # This fixture probably uses internal API, so it can be broken at any time :(
-# @pytest.fixture(scope="module")
-# def generator(request) -> GeneratorTool:
-#     return GeneratorTool(
-#         generator_factory=DefaultGeneratorFactory(
-#             ProgramGenerator.ProgramGenerator,
-#             model_class=None,
-#             cooldown=0.2,
-#             weights=None,
-#             lock=None,
-#             listener_classes=None,
-#         ),
-#         rule="prog",
-#         out_format="",
-#         limit=RuleSize(depth=20, tokens=RuleSize.max.tokens),
-#         population=(
-#             DefaultPopulation(
-#                 "tests/autotests/program_examples/", "grtp", PickleTreeCodec()
-#             )
-#             if True
-#             else None
-#         ),
-#         generate=True,
-#         mutate=True,
-#         recombine=True,
-#         keep_trees=False,
-#         transformers=[],
-#         serializer=simple_space_serializer,
-#         cleanup=False,
-#         encoding="utf-8",
-#         errors="strict",
-#         dry_run=False,
-#     )
-#
-#
-# @pytest.fixture(params=range(100))
-# def program(generator, request) -> str:
-#     # Grammarinator's API cannot return plain string, it can either write to the file or to the stdout
-#     # So we catch stdout
-#     with io.StringIO() as buf, redirect_stdout(buf):
-#         with generator:
-#             generator.create(request.param)
-#         out = buf.getvalue()
-#     return out
-#
-#
-# class TestParser:
-#     def test_id(self, program: str):
-#         tree_before, is_valid = prog_to_tree(program)
-#         assert is_valid
-#         program_after = tree_to_prog(tree_before)
-#         tree_after, is_valid_after = prog_to_tree(program_after)
-#         assert is_valid_after
-#         assert nodes_count(tree_before) == nodes_count(tree_after)
-#
-#     def test_wrong(self, program: str):
-#         reg = re.compile("[=,]", re.X)
-#         if reg.search(program):
-#             program_bad = reg.sub("", program)
-#             _, is_valid_bad = prog_to_tree(program_bad)
-#             assert not is_valid_bad
+# This file contains test cases that you need to pass to get a grade
+# You MUST NOT touch anything here except ONE block below
+# You CAN modify this file IF AND ONLY IF you have found a bug and are willing to fix it
+# Otherwise, please report it
+import inspect
+import io
+from contextlib import redirect_stdout
+
+import pytest
+import re
+from grammarinator.runtime import RuleSize, simple_space_serializer
+from grammarinator.tool import (
+    PickleTreeCodec,
+    GeneratorTool,
+    DefaultGeneratorFactory,
+    DefaultPopulation,
+)
+
+import ProgramGenerator
+
+# Fix import statements in try block to run tests
+try:
+    from project.parser_task11 import prog_to_tree, nodes_count, tree_to_prog
+except ImportError:
+    pytestmark = pytest.mark.skip("Task 11 is not ready to test!")
+
+
+# This fixture probably uses internal API, so it can be broken at any time :(
+@pytest.fixture(scope="module")
+def generator(request) -> GeneratorTool:
+    return GeneratorTool(
+        generator_factory=DefaultGeneratorFactory(
+            ProgramGenerator.ProgramGenerator,
+            model_class=None,
+            cooldown=0.2,
+            weights=None,
+            lock=None,
+            listener_classes=None,
+        ),
+        rule="prog",
+        out_format="",
+        limit=RuleSize(depth=20, tokens=RuleSize.max.tokens),
+        population=(
+            DefaultPopulation(
+                "tests/autotests/program_examples/", "grtp", PickleTreeCodec()
+            )
+            if True
+            else None
+        ),
+        generate=True,
+        mutate=True,
+        recombine=True,
+        keep_trees=False,
+        transformers=[],
+        serializer=simple_space_serializer,
+        cleanup=False,
+        encoding="utf-8",
+        errors="strict",
+        dry_run=False,
+    )
+
+
+@pytest.fixture(params=range(100))
+def program(generator, request) -> str:
+    # Grammarinator's API cannot return plain string, it can either write to the file or to the stdout
+    # So we catch stdout
+    with io.StringIO() as buf, redirect_stdout(buf):
+        with generator:
+            generator.create(request.param)
+        out = buf.getvalue()
+    return out
+
+
+class TestParser:
+    def test_id(self, program: str):
+        tree_before, is_valid = prog_to_tree(program)
+        assert is_valid
+        program_after = tree_to_prog(tree_before)
+        tree_after, is_valid_after = prog_to_tree(program_after)
+        assert is_valid_after
+        assert nodes_count(tree_before) == nodes_count(tree_after)
+
+    def test_wrong(self, program: str):
+        reg = re.compile("[=,]", re.X)
+        if reg.search(program):
+            program_bad = reg.sub("", program)
+            _, is_valid_bad = prog_to_tree(program_bad)
+            assert not is_valid_bad


### PR DESCRIPTION
Ладно, это было просто.
Некоторый вопрос — я вот почитал в интернете, что ANTLR4 при разборе грамматик вида
```antlr
expr
  : NAME
  | expr AND expr
  | expr OR expr;
```
раскрывает его в
```antlr
expr  : NAME  | (expr AND expr) | (expr OR expr);
```
Что было немного контринтуитивно, ведь тогда надо оборачивать любое правило в кавычки
Но в то же время в офф. документации они получают нужный эффект спокойно: https://github.com/antlr/antlr4/blob/master/doc/left-recursion.md
Я в этом убедился, когда играл в antlr lab с грамматикой — всё действительно нормально парсится
Но если поставить скобки, как это написано в грамматике, то оно почему-то разваливается. Хотя по логике должно быть эквивалентным